### PR TITLE
feat(AAS-14): create class to export annotation to cocojson

### DIFF
--- a/frontend/src/components/canvas/useCOCOJSON.tsx
+++ b/frontend/src/components/canvas/useCOCOJSON.tsx
@@ -1,0 +1,63 @@
+// This file contains a hook to create a COCO JSON object and export it. It should be moved into a separate folder in future!
+type cocoInfo = {
+  year: string // in format YYYY
+  version: string
+  description: string
+  contributor: string
+  url: string
+  date_created: string // iso 8601 date format
+}
+
+type cocoCategory = {
+  id: number
+  name: string
+  supercategory: string
+}
+
+type cocoImage = {
+  id: number
+  license: number
+  file_name: string
+  height: number
+  width: number
+  date_captured: string //iso 8601 date format
+}
+
+type cocoAnnotation = {
+  id: number
+  image_id: number
+  category_id: number
+  bbox: number[] // length = 4
+  area: number
+  segmentation: number[][] // array of numbers(length=2)
+  iscrowd: number
+}
+
+type cocoLicense = {
+  id: number
+  url: string
+  name: string
+}
+
+class CocoJsonObj {
+  constructor(
+    public info: cocoInfo,
+    public licenses: cocoLicense[],
+    public categories: cocoCategory[],
+    public images: cocoImage[],
+    public annotations: cocoAnnotation[],
+  ) {}
+
+  public export = (): string => {
+    return JSON.stringify({
+      info: this.info,
+      licenses: this.licenses,
+      categories: this.categories,
+      images: this.images,
+      annotations: this.annotations,
+    })
+  }
+}
+
+export type { cocoInfo, cocoLicense, cocoCategory, cocoImage, cocoAnnotation }
+export default CocoJsonObj


### PR DESCRIPTION
## Description
This PR creates a simple class and types for exporting to cocojson (in a button press etc).
When the state for frontend is created, we will need to add hooks to convert the state into the class.

This could be tested with a mock, but we should wait for annotation concept to be done. Once it's done we can then integrate and test this with the annotation concept.

## Required Checklist
[Jira Ticket Link](https://avian-annotator.atlassian.net/browse/AAS-14)

- [x] I have tested the code
- [ ] I have updated documentation if needed
- [x] Jira ticket has been linked
- [ ] I have updated /.github/CODEOWNERS as appropriate (trial/testing)

## Optional Checklist
[Loom Video Link]()
- [ ] Tests have been added/updated as needed
- [ ] I have linked a loom video

See [docs](https://avian-annotator.atlassian.net/wiki/x/AgD6) for how to fill this out and the motivation for this